### PR TITLE
Option for lock screen command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Tomate plugin that shows a full screen window which prevents users from using th
 
 Optionally runs a command at the end of a pause to lock the screen.
 
+*Note:* Despite its superficial similarities the pause screen does not provide the security a proper lock screen does.
+
 Development
 -----------
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Tomate Break Screen Plugin
 
 Tomate plugin that shows a full screen window which prevents users from using the computer during a break.
 
+Optionally runs a command at the end of a pause to lock the screen.
+
 Development
 -----------
 


### PR DESCRIPTION
I use tomate-gtk in a shared office and do not always return to my seat by the time the pause runs out. In that case my desktop is openly visible. Instead I would like to have the lock screen start up, when the pause runs out.

Unfortunately, there is no single command one can issue to run the lock screen. It seems like every desktop environment has its own and then there are more independent once.

Therefore, I added an option with a free text field, similar to the tomate-exec-plugin. If the text field is not empty and a pause ends, the plugin runs the command represented by the text fields contents.

I know that the pause screen is not as secure (and probably not intended to be as secure) as lock screen applications try to be. But because users might get confused about the fact I added a note to the README.md, to remind them that the pause screen does not prevent others from accessing the computer.


Alternatively I could have used the tomate-exec-plugin and run a command at session ends. However, I would then have to add a wrapper around the lock screen command that checks whether the last session was a pause. So, I am aware that you might decide to not add the change, because of that.